### PR TITLE
fix: include vicinae binary path to allow wlr-clip resolution

### DIFF
--- a/vicinae.nix
+++ b/vicinae.nix
@@ -131,7 +131,7 @@ in
           nodejs
           qt6.qtwayland
           wayland
-          "${placeholder "out"}/bin"
+          (placeholder "out")
         ]}
     '';
 


### PR DESCRIPTION
This pull request adds the binary output path of the derivation itself to the wrapped vicinae program so that it can resolve the wlr-clip binary present in the same directory.