### PR TITLE
fix: modify systemd service configuration

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -32,8 +32,9 @@ in {
     systemd.user.services.vicinae = {
       Unit = {
         Description = "Vicinae server daemon";
-        After = ["graphical-session-pre.target"];
+        After = ["graphical-session.target"];
         PartOf = ["graphical-session.target"];
+        BindsTo = ["graphical-session.target"];
       };
       Service = {
         Type = "simple";


### PR DESCRIPTION
This pull request adapts the generated systemd service to bind to the `graphical-session.target`. This allows for proper services starting with other wayland compositors.

resolves #4 