### PR TITLE
bump to version 0.7.4, fix missing version in about page

### DIFF
--- a/vicinae.nix
+++ b/vicinae.nix
@@ -29,8 +29,8 @@ let
   src = fetchFromGitHub {
     owner = "vicinaehq";
     repo = "vicinae";
-    rev = "v0.7.0";
-    hash = "sha256-tXyP7KJxiLzmm1XrhPnCemg+TEBB8tuTlGyCKiTIdYQ=";
+    rev = "v0.7.3";
+    hash = "sha256-ByxpEs9y7nv0wE7DD7zKIScQZMFMeGD/y/EsPxPVZxI=";
   };
 
   # Prepare node_modules for api folder

--- a/vicinae.nix
+++ b/vicinae.nix
@@ -29,8 +29,8 @@ let
   src = fetchFromGitHub {
     owner = "vicinaehq";
     repo = "vicinae";
-    rev = "v0.7.3";
-    hash = "sha256-ByxpEs9y7nv0wE7DD7zKIScQZMFMeGD/y/EsPxPVZxI=";
+    rev = "v0.7.4";
+    hash = "sha256-2ZhmUOLrS6Izilwr7GgmZZPNFYK46mWQ3m+ZNo31VPg=";
   };
 
   # Prepare node_modules for api folder

--- a/vicinae.nix
+++ b/vicinae.nix
@@ -56,6 +56,7 @@ in
     inherit src;
 
     cmakeFlags = [
+        "-DVICINAE_GIT_TAG=${src.rev}"
         "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
         "-DCMAKE_INSTALL_DATAROOTDIR=share"
         "-DCMAKE_INSTALL_BINDIR=bin"


### PR DESCRIPTION
the git tag in necessary to display the currect version in the about page instead of  v0.0.0 

<img width="993" height="593" alt="image" src="https://github.com/user-attachments/assets/84f384c8-aa56-48c2-bd5d-552db6d74647" />
