### PR TITLE
chore: update upstream rev to v0.8.0

### DIFF
--- a/vicinae.nix
+++ b/vicinae.nix
@@ -29,8 +29,8 @@ let
   src = fetchFromGitHub {
     owner = "vicinaehq";
     repo = "vicinae";
-    rev = "v0.7.4";
-    hash = "sha256-2ZhmUOLrS6Izilwr7GgmZZPNFYK46mWQ3m+ZNo31VPg=";
+    rev = "v0.8.0";
+    hash = "sha256-5dde11a03940a244ac104347fc3c05c7e1402812";
   };
 
   # Prepare node_modules for api folder

--- a/vicinae.nix
+++ b/vicinae.nix
@@ -30,7 +30,7 @@ let
     owner = "vicinaehq";
     repo = "vicinae";
     rev = "v0.8.0";
-    hash = "sha256-5dde11a03940a244ac104347fc3c05c7e1402812";
+    hash = "";
   };
 
   # Prepare node_modules for api folder

--- a/vicinae.nix
+++ b/vicinae.nix
@@ -30,7 +30,7 @@ let
     owner = "vicinaehq";
     repo = "vicinae";
     rev = "v0.8.0";
-    hash = "";
+    hash = "sha256-VYqpOI+aFOCbtU3ZBGRd8/YEr8AgO6Ruq/H3J9GrosE=";
   };
 
   # Prepare node_modules for api folder


### PR DESCRIPTION
This pull request updates the upstream vicinae rev to `v0.8.0`