### PR TITLE
chore: update upstream rev to v0.8.1

### DIFF
--- a/vicinae.nix
+++ b/vicinae.nix
@@ -30,7 +30,7 @@ let
     owner = "vicinaehq";
     repo = "vicinae";
     rev = "v0.8.1";
-    hash = "";
+    hash = "sha256-HlNorGRnYr+dmEQkn0AAOyhoma+0X3m6S9Jev7MwvSU=";
   };
 
   # Prepare node_modules for api folder

--- a/vicinae.nix
+++ b/vicinae.nix
@@ -29,8 +29,8 @@ let
   src = fetchFromGitHub {
     owner = "vicinaehq";
     repo = "vicinae";
-    rev = "v0.8.0";
-    hash = "sha256-VYqpOI+aFOCbtU3ZBGRd8/YEr8AgO6Ruq/H3J9GrosE=";
+    rev = "v0.8.1";
+    hash = "";
   };
 
   # Prepare node_modules for api folder


### PR DESCRIPTION
This pull request updates the vicinae upstream rev to `v0.8.1`